### PR TITLE
Add a displayName for React dev support Fixes #1

### DIFF
--- a/NativeListener.js
+++ b/NativeListener.js
@@ -45,6 +45,7 @@ var React = require('react'),
   NativeListener;
 
 NativeListener = React.createClass({
+  displayName: 'NativeListener',
   propTypes: propTypes,
   componentDidMount: function () {
     var props = this.props,


### PR DESCRIPTION
Without setting the display name React dev tools renders the component with the generic name `Unknown`.
Fixes #1
